### PR TITLE
FIX: Defined subscriptions to pulumi

### DIFF
--- a/.github/workflows/pulumi-go-infra.yaml
+++ b/.github/workflows/pulumi-go-infra.yaml
@@ -103,3 +103,4 @@ jobs:
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
As can be seen in this workflow: https://github.com/Cluster-ry/titeenipeli_25/actions/runs/9911534846/job/27384424675
The subscription id is missing so deployment fails.