### PR TITLE
#215: Design client token authentication

### DIFF
--- a/src/openapi/components/responses/200TelegramAuthorization.yaml
+++ b/src/openapi/components/responses/200TelegramAuthorization.yaml
@@ -1,0 +1,5 @@
+description: Provides token that can be used to authenticate user.
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/telegramToken.yaml"

--- a/src/openapi/components/responses/200UserAuthorization.yaml
+++ b/src/openapi/components/responses/200UserAuthorization.yaml
@@ -1,4 +1,4 @@
-description: Set authorization token and provide user details.
+description: Sets authorization cookie and provides user details.
 headers:
   Set-Cookie:
     schema:
@@ -6,4 +6,4 @@ headers:
 content:
   application/json:
     schema:
-      $ref: "../schemas/guild.yaml"
+      $ref: "../schemas/user.yaml"

--- a/src/openapi/components/schemas/telegramAuthorizationData.yaml
+++ b/src/openapi/components/schemas/telegramAuthorizationData.yaml
@@ -1,6 +1,7 @@
 type: object
 properties:
-  id: integer
+  id:
+    type: integer
   firstName:
     type: string
   lastName:
@@ -8,8 +9,4 @@ properties:
   username:
     type: string
   photoUrl:
-    type: string
-  authDate:
-    type: string
-  hash:
     type: string

--- a/src/openapi/components/schemas/telegramToken.yaml
+++ b/src/openapi/components/schemas/telegramToken.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  token:
+    type: string
+    minLength: 32
+    maxLength: 32

--- a/src/openapi/components/securitySchemas/botAuth.yaml
+++ b/src/openapi/components/securitySchemas/botAuth.yaml
@@ -1,0 +1,3 @@
+type: apikey
+in: header
+name: X-BOT-KEY

--- a/src/openapi/openapi.yaml
+++ b/src/openapi/openapi.yaml
@@ -39,9 +39,13 @@ paths:
   /map/pixels:
     $ref: "./paths/map/pixels.yaml"
   /users:
-    $ref: "./paths/users.yaml"
+    $ref: "./paths/users/users.yaml"
+  /users/authenticate:
+    $ref: "./paths/users/authenticate.yaml"
 
 components:
   securitySchemes:
     bearerAuth:
       $ref: "./components/securitySchemas/bearerAuth.yaml"
+    botAuth:
+      $ref: "./components/securitySchemas/botAuth.yaml"

--- a/src/openapi/paths/users/authenticate.yaml
+++ b/src/openapi/paths/users/authenticate.yaml
@@ -1,0 +1,19 @@
+post:
+  tags:
+    - users
+  summary: "Authenticates user using token."
+  operationId: "authenticateUser"
+  requestBody:
+    description: "User authentication token received from Telegram."
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../../components/schemas/telegramToken.yaml"
+  responses:
+    "200":
+      $ref: "../../components/responses/200UserAuthorization.yaml"
+    "403":
+      $ref: "../../components/responses/403AuthorizationError.yaml"
+  security:
+    - botAuth: []

--- a/src/openapi/paths/users/users.yaml
+++ b/src/openapi/paths/users/users.yaml
@@ -1,7 +1,7 @@
 post:
   tags:
     - users
-  summary: "Creates or logs in user."
+  summary: "Creates user."
   operationId: "postUsers"
   requestBody:
     description: "User details received from Telegram."
@@ -9,12 +9,14 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../components/schemas/telegramAuthorizationData.yaml"
+          $ref: "../../components/schemas/telegramAuthorizationData.yaml"
   responses:
     "200":
-      $ref: "../components/responses/200UserAuthorization.yaml"
+      $ref: "../../components/responses/200TelegramAuthorization.yaml"
     "403":
-      $ref: "../components/responses/403AuthorizationError.yaml"
+      $ref: "../../components/responses/403AuthorizationError.yaml"
+  security:
+    - botAuth: []
 
 put:
   tags:
@@ -27,13 +29,13 @@ put:
     content:
       application/json:
         schema:
-          $ref: "../components/schemas/guild.yaml"
+          $ref: "../../components/schemas/guild.yaml"
   responses:
     "200":
       description: Guild details updated!
     "400":
-      $ref: "../components/responses/400ClientError.yaml"
+      $ref: "../../components/responses/400ClientError.yaml"
     "401":
-      $ref: "../components/responses/401Unauthorized.yaml"
+      $ref: "../../components/responses/401Unauthorized.yaml"
   security:
-    - bearerAuth: []
+    - botAuth: []


### PR DESCRIPTION
Closes #215 

Redesing OpenAPI spec so that bot can create users effectively and frontend can be authenticated with ease.