### PR TITLE
#301: Prevent massive busy waiting

### DIFF
--- a/src/backend/Titeenipeli.Grpc/Common/GrpcConnection.cs
+++ b/src/backend/Titeenipeli.Grpc/Common/GrpcConnection.cs
@@ -33,6 +33,8 @@ public class GrpcConnection<TResponseStream> : IGrpcConnection<TResponseStream> 
         Task queueCompletion = ResponseStreamQueue.Reader.Completion;
         while (!queueCompletion.IsCompleted)
         {
+            await Task.Delay(KeepAliveCheckFrequencyInSeconds * 1000);
+
             if (_lastMessageSent > DateTime.Now - TimeSpan.FromSeconds(KeepAliveFrequencyInSeconds))
             {
                 continue;
@@ -48,8 +50,6 @@ public class GrpcConnection<TResponseStream> : IGrpcConnection<TResponseStream> 
                 Dispose();
                 break;
             }
-
-            await Task.Delay(KeepAliveCheckFrequencyInSeconds * 1000);
         }
     }
 


### PR DESCRIPTION
Prevent massive busy looping by moving poll waiting statement to its right full place.