### PR TITLE
#306: Fix out of bound error in map injector

### DIFF
--- a/src/backend/Titeenipeli/Services/BackgroundGraphicsService.cs
+++ b/src/backend/Titeenipeli/Services/BackgroundGraphicsService.cs
@@ -44,7 +44,7 @@ public class BackgroundGraphicsService : IBackgroundGraphicsService
 
     public byte[]? GetBackgroundGraphic(Coordinate coordinate)
     {
-        if (coordinate.X < 0 || coordinate.X > _splitBitmapWidth || coordinate.Y < 0 || coordinate.Y > _splitBitmapHeight)
+        if (coordinate.X < 0 || coordinate.X >= _splitBitmapWidth || coordinate.Y < 0 || coordinate.Y >= _splitBitmapHeight)
         {
             return null;
         }


### PR DESCRIPTION
Correct upper bound checks in `GetBackgroundGraphic` service.