### PR TITLE
229 fix bug about placing a pixel on panning the map

### DIFF
--- a/src/frontend/src/components/gameMap/BackgroundRectangle.tsx
+++ b/src/frontend/src/components/gameMap/BackgroundRectangle.tsx
@@ -1,12 +1,23 @@
 import { Sprite } from "@pixi/react";
-import { Texture } from "pixi.js";
+import { FederatedPointerEvent, Texture } from "pixi.js";
 import BackgroundRectangleProps from "../../models/BackgroundRectangleProps";
+import { useInputEventStore } from "../../stores/inputEventStore";
 
 const backgroundGraphicSize = 32;
 
 const BackgroundRectangle = ({ x, y, width, height, backgroundGraphic, onClick }: BackgroundRectangleProps) => {
+    const inputEventStore = useInputEventStore();
+
     // When a client clicks a pixel
-    const handleClick = () => {
+    const handleEvent = (event: FederatedPointerEvent) => {
+        if (event.pointerType === "mouse" && event.button !== 0) {
+            return;
+        }
+
+        if (inputEventStore.moving || inputEventStore.moveEnded.getTime() > new Date().getTime() - 300) {
+            return;
+        }
+
         onClick({ x: x, y: y });
     };
 
@@ -21,7 +32,8 @@ const BackgroundRectangle = ({ x, y, width, height, backgroundGraphic, onClick }
             cullable={true}
             texture={texture}
             eventMode="static"
-            pointertap={handleClick}
+            mousedown={handleEvent}
+            tap={handleEvent}
         />
     );
 };

--- a/src/frontend/src/components/gameMap/GameMap.tsx
+++ b/src/frontend/src/components/gameMap/GameMap.tsx
@@ -10,6 +10,7 @@ import { useUser } from "../../hooks/useUser.ts";
 import { EffectContainer, EffectContainerHandle } from "./particleEffects";
 import { useOptimisticConquer } from "../../hooks/useOptimisticConquer.ts";
 import BackgroundRectangle from "./BackgroundRectangle.tsx";
+import { useInputEventStore } from "../../stores/inputEventStore.ts";
 
 /**
  * @component GameMap
@@ -26,6 +27,7 @@ import BackgroundRectangle from "./BackgroundRectangle.tsx";
 const GameMap: FC = () => {
     const pixelsBoundingBox = useNewMapStore((state) => state.pixelsBoundingBox);
     const map = useNewMapStore((state) => state.map);
+    const inputEventStore = useInputEventStore();
     const effectRef = useRef<EffectContainerHandle>(null);
     const user = useUser();
     const conquer = useOptimisticConquer(user, effectRef);
@@ -84,8 +86,15 @@ const GameMap: FC = () => {
                 width={window.innerWidth}
                 height={window.innerHeight}
                 options={{ background: 0xffffff, resizeTo: window }}
+                onContextMenu={(e) => e.preventDefault()}
             >
-                <Viewport width={window.innerWidth} height={window.innerHeight} boundingBox={mappedBoundingBox}>
+                <Viewport
+                    width={window.innerWidth}
+                    height={window.innerHeight}
+                    boundingBox={mappedBoundingBox}
+                    onMoveStart={() => inputEventStore.setMoving(true)}
+                    onMoveEnd={() => inputEventStore.setMoving(false)}
+                >
                     <Container>{pixelElements}</Container>
                     <EffectContainer ref={effectRef} />
                 </Viewport>

--- a/src/frontend/src/components/gameMap/Viewport.tsx
+++ b/src/frontend/src/components/gameMap/Viewport.tsx
@@ -47,6 +47,12 @@ const PixiComponentViewport = PixiComponent("Viewport", {
                 maxScale: 2,
             })
             .moveCenter(centerX, centerY);
+        viewport.options.disableOnContextMenu = true;
+        viewport.options.stopPropagation = true;
+
+        viewport.addEventListener("pinch-start", props.onMoveStart);
+        viewport.addEventListener("drag-start", props.onMoveStart);
+        viewport.addEventListener("moved-end", props.onMoveEnd);
 
         return viewport;
     },

--- a/src/frontend/src/models/ViewportProps.ts
+++ b/src/frontend/src/models/ViewportProps.ts
@@ -5,6 +5,8 @@ interface ViewportProps {
     height: number;
     boundingBox: ViewportBoundingBox;
     children?: React.ReactNode;
+    onMoveStart: () => void;
+    onMoveEnd: () => void;
 }
 
 export default ViewportProps;

--- a/src/frontend/src/stores/inputEventStore.ts
+++ b/src/frontend/src/stores/inputEventStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+export interface InputEventStore {
+    moving: boolean;
+    moveEnded: Date;
+    setMoving: (newPinchingState: boolean) => void;
+}
+
+export const useInputEventStore = create<InputEventStore>((set) => ({
+    moving: true,
+    moveEnded: new Date(0),
+    setMoving: (newMovingState: boolean) => {
+        if (newMovingState) {
+            set({ moving: newMovingState });
+        } else {
+            set({ moving: newMovingState, moveEnded: new Date() });
+        }
+    },
+}));


### PR DESCRIPTION
Closes #208 closes #229

Fixes camera panning and accidental pixel placement issues by introducing delay, which prevents pixel placement when camera is moving and after camera moving for some millisconds.

This PR has been implemented using cascading style. #334 has to be merged first.