### PR TITLE
#307: Fill fills only not owned pixels

### DIFF
--- a/src/backend/Titeenipeli.Tests/GameLogic/MapUpdaterTest.cs
+++ b/src/backend/Titeenipeli.Tests/GameLogic/MapUpdaterTest.cs
@@ -116,6 +116,24 @@ public class MapUpdaterTest
             yield return new TestCaseData(
                 new[,]
                 {
+                    { Clus, Clus, CLUS, Clus, Clus },
+                    { Clus, ALGO, Clus, Clus, Clus },
+                    { Clus, Algo, Clus, Clus, Clus },
+                    { Clus, Algo, Clus, Clus, Clus },
+                    { Clus, Clus, Clus, Clus, Clus }
+                },
+                new[] { (GuildName.Cluster, new Coordinate(2, 3)) },
+                new[,]
+                {
+                    { Clus, Clus, CLUS, Clus, Clus },
+                    { Clus, ALGO, Clus, Clus, Clus },
+                    { Clus, Clus, Clus, Clus, Clus },
+                    { Clus, Clus, Clus, Clus, Clus },
+                    { Clus, Clus, Clus, Clus, Clus }
+                }).SetName("Should fill cut cells");
+            yield return new TestCaseData(
+                new[,]
+                {
                     { Clus, Clus, CLUS, Clus },
                     { Clus, ALGO, TiKi, Clus },
                     { Clus, Algo, Algo, None },
@@ -126,9 +144,9 @@ public class MapUpdaterTest
                 {
                     { Clus, Clus, CLUS, Clus },
                     { Clus, ALGO, Clus, Clus },
-                    { Clus, Clus, Clus, Clus },
+                    { Clus, Algo, Algo, Clus },
                     { Clus, Clus, Clus, Clus }
-                }).SetName("Should not fill spawn cells");
+                }).SetName("Should not fill spawn connected cells");
             yield return new TestCaseData(
                 new[,]
                 {

--- a/src/backend/Titeenipeli/GameLogic/MapCalculationDataTypes/Node.cs
+++ b/src/backend/Titeenipeli/GameLogic/MapCalculationDataTypes/Node.cs
@@ -5,7 +5,7 @@ namespace Titeenipeli.GameLogic.MapCalculationDataTypes;
 
 public record Node
 {
-    public required GuildName? Guild { get; init; }
+    public required GuildName? Guild { get; set; }
     public HashSet<int> Neighbours { get; } = [];
     public HashSet<Coordinate> Pixels { get; } = [];
     public bool HasSpawn { get; set; }


### PR DESCRIPTION
Closes #307. Fixes the issue by doing two minor modifications:
1. Make it so that fill fills only pixels that are owned by nobody.
2. Change order of cut and fiil so that cuts are done before fills. This makes it possible to fill areas immediately that were just cut.