### PR TITLE
#377: Postpone background task running to prevent database errors on startup

### DIFF
--- a/src/backend/Titeenipeli/Services/BackgroundServices/AsynchronousTimedBackgroundService.cs
+++ b/src/backend/Titeenipeli/Services/BackgroundServices/AsynchronousTimedBackgroundService.cs
@@ -29,11 +29,11 @@ public class AsynchronousTimedBackgroundService<TService, TServiceImplementation
 
     private async Task RunPeriodic(CancellationToken cancellationToken)
     {
-        using PeriodicTimer timer = new PeriodicTimer(period);
-        do
+        using PeriodicTimer timer = new(period);
+        while (await timer.WaitForNextTickAsync(cancellationToken))
         {
             await DoWorkWithErrorHandling();
-        } while (await timer.WaitForNextTickAsync(cancellationToken));
+        }
     }
 
     private async Task DoWorkWithErrorHandling()


### PR DESCRIPTION
Closes #377

Fix database errors by postponing background task running.