### PR TITLE
#391: Fix pixel placement in spawn intersections

### DIFF
--- a/src/backend/Titeenipeli.InMemoryMapProvider/MapProvider.cs
+++ b/src/backend/Titeenipeli.InMemoryMapProvider/MapProvider.cs
@@ -62,6 +62,6 @@ public class MapProvider : IMapProvider
     public bool IsSpawn(Coordinate pixelCoordinate)
     {
         var pixel = GetByCoordinate(pixelCoordinate);
-        return !(pixel?.User == null || (pixel.User.SpawnX != pixel.X && pixel.User.SpawnY != pixel.Y));
+        return pixel?.User != null && pixel.User.SpawnX == pixel.X && pixel.User.SpawnY == pixel.Y;
     }
 }


### PR DESCRIPTION
Closes #391 

There was bad bug that prevented pixel placement when spawn was on same row or column and pixel was owned by a user.