### PR TITLE
#481 Optimize powerup pixel placement + enable spawn setting with proper map updates

### DIFF
--- a/src/backend/Titeenipeli/GameLogic/MapUpdater.cs
+++ b/src/backend/Titeenipeli/GameLogic/MapUpdater.cs
@@ -53,9 +53,9 @@ public class MapUpdater
             var xSize = map.GetUpperBound(0) + 1;
             var ySize = map.GetUpperBound(1) + 1;
             // Normally you would see strict greater/less than, but due to border behaviour we can do just a minor
-            // optimization here with greater/less than or equal 
-            var coordinateIsOutOfBounds = 
-                pixelCoordinate.Y <= 0 || pixelCoordinate.Y >= ySize || 
+            // optimization here with greater/less than or equal
+            var coordinateIsOutOfBounds =
+                pixelCoordinate.Y <= 0 || pixelCoordinate.Y >= ySize ||
                 pixelCoordinate.X <= 0 || pixelCoordinate.X >= xSize;
             // Due to previous out of bound behaviour MapBorder should never be encountered here but better safe than
             // sorry. Overriding a border would be rather bad after all...

--- a/src/backend/Titeenipeli/Services/MapUpdaterService.cs
+++ b/src/backend/Titeenipeli/Services/MapUpdaterService.cs
@@ -81,7 +81,7 @@ public class MapUpdaterService(
                 user.SpawnY = spawnPoint.Y;
 
                 var changedPixels = _mapUpdater.PlacePixel(map, spawnPoint + new Coordinate(1, 1), user, PixelType.Spawn);
-                
+
                 DoGrpcUpdate(map, changedPixels);
                 DoDatabaseUpdate(changedPixels, user);
             }


### PR DESCRIPTION
Map updater now has a bunch placement method that takes a list of coords, places those all (if legal) and only then cuts and fills.

Also single pixel placement takes an optional bool to denote whether the placed pixel should be spawn.